### PR TITLE
[BUG] Handle paths on different platforms

### DIFF
--- a/enpaki.js
+++ b/enpaki.js
@@ -226,7 +226,7 @@ module.exports = class Enpaki extends Readable {
    */
   readFile(filename) {
     let code = this.compile(filename);
-    let moduleIdentity = this.moduleIdentity(filename);
+    let moduleIdentity = process.platform == "win32" ? this.moduleIdentity(filename).split("\\").join("/") : this.moduleIdentity(filename);
 
     code = code
       .replace(/^#!.*/, '')


### PR DESCRIPTION
Handle paths on different platforms, which led to escaped characters on Windows systems.